### PR TITLE
switch request SSL options to use TLSv1

### DIFF
--- a/lib/azericard/request.rb
+++ b/lib/azericard/request.rb
@@ -13,7 +13,8 @@ module Azericard
         followlocation: true,
         ssl_verifypeer: false,
         ssl_verifyhost: 2,
-        cainfo: 'a.cer',
+        sslversion: :tlsv1,
+        ssl_cipher_list: 'RC4-SHA',
         headers: {
           "User-Agent" => Azericard.user_agent
         },


### PR DESCRIPTION
In the middle of April, 2015 AzeriCard switched from SSLv3 to TLSv1
See #1 
