### PR TITLE
switch request SSL options to use TLSv1.2

### DIFF
--- a/lib/azericard/request.rb
+++ b/lib/azericard/request.rb
@@ -13,7 +13,7 @@ module Azericard
         followlocation: true,
         ssl_verifypeer: false,
         ssl_verifyhost: 2,
-        sslversion: :tlsv1,
+        sslversion: 'tlsv1.2',
         ssl_cipher_list: 'RC4-SHA',
         headers: {
           "User-Agent" => Azericard.user_agent


### PR DESCRIPTION
AzeriCard switching to TLSv1.2 completely, from 1st of June, 2015.
See #3
