### PR TITLE
use ECDHE-RSA-AES256-GCM-SHA384 cipher list

### DIFF
--- a/lib/azericard/request.rb
+++ b/lib/azericard/request.rb
@@ -14,7 +14,7 @@ module Azericard
         ssl_verifypeer: false,
         ssl_verifyhost: 2,
         sslversion: 'tlsv1.2',
-        ssl_cipher_list: 'RC4-SHA',
+        ssl_cipher_list: 'ECDHE-RSA-AES256-GCM-SHA384',
         headers: {
           "User-Agent" => Azericard.user_agent
         },


### PR DESCRIPTION
Azericard switched cipher list from RC4-SHA to ECDHE-RSA-AES256-GCM-SHA384
See #5
